### PR TITLE
Fixes Map.size warning

### DIFF
--- a/lib/nary_tree.ex
+++ b/lib/nary_tree.ex
@@ -564,7 +564,7 @@ defmodule NaryTree do
   end
 
   defimpl Enumerable do
-    def count(%NaryTree{nodes: nodes}), do: {:ok, Map.size(nodes)}
+    def count(%NaryTree{nodes: nodes}), do: {:ok, Kernel.map_size(nodes)}
 
     @doc """
     ## TODO


### PR DESCRIPTION
Fixes this warning:

```
==> nary_tree
Compiling 2 files (.ex)
warning: Map.size/1 is deprecated. Use Kernel.map_size/1 instead
  lib/nary_tree.ex:567
```